### PR TITLE
[BUG] duplicate frames when frame._allow_duplicates is disabled

### DIFF
--- a/stagger/frames.py
+++ b/stagger/frames.py
@@ -107,7 +107,7 @@ class Frame(metaclass=abc.ABCMeta):
                 warn("{0}: Duplicate frame; only the first instance is kept"
                      .format(frames[0].frameid),
                      DuplicateFrameWarning)
-            return frames[0]
+            return frames[0:1]
 
     @classmethod
     def _in_version(self, *versions):


### PR DESCRIPTION
Frame._merge should return a list of only one frame not the first frame itself when cls._allow_duplicates is disabled.

Without this correction, stagger is not able to tag some mp3, for example podcasts from "France Inter".